### PR TITLE
Add examples of image-catalog interactivity

### DIFF
--- a/image_catalog_interactivity/08c_Interactive_Image-Catalog_Visualization.ipynb
+++ b/image_catalog_interactivity/08c_Interactive_Image-Catalog_Visualization.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "5e998f59",
+   "id": "f8af644d",
    "metadata": {},
    "source": [
     "<b><img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250, style=\"padding: 10px\"> \n",
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4ffd340b",
+   "id": "2c87840a",
    "metadata": {},
    "source": [
     "**Credit:** This tutorial builds upon notebooks developed for DP0.1 by Leanne Guy. Please consider acknowledging Leanne Guy and Keith Bechtol in any publications or software releases that make use of this notebook's contents."
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8784c41a",
+   "id": "cee61e4e",
    "metadata": {},
    "source": [
     "### Learning Objectives\n",
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "02f6c081",
+   "id": "9b553dbd",
    "metadata": {},
    "source": [
     "### Logistics\n",
@@ -52,7 +52,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ab94b00c",
+   "id": "9df8d968",
    "metadata": {},
    "source": [
     "### Setup"
@@ -61,7 +61,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dfc66023",
+   "id": "afe45649",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -97,7 +97,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0d3648ef",
+   "id": "74a085f6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,7 +111,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24f0b284",
+   "id": "345fe1db",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4ec019b2",
+   "id": "03965977",
    "metadata": {},
    "source": [
     "### 1. Data Preparation\n",
@@ -135,7 +135,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "715cb238",
+   "id": "607944fc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,7 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "faecc27c",
+   "id": "06714a6d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -164,7 +164,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "320e22df",
+   "id": "031787fd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -178,7 +178,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f7f44ddd",
+   "id": "52729753",
    "metadata": {},
    "source": [
     "### 2. Interactively Select Objects Overlaid on an Image with an Adjustable Colorbar Range\n",
@@ -189,7 +189,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cce82c55",
+   "id": "e6525bc6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -226,7 +226,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0456e07e",
+   "id": "1467907f",
    "metadata": {},
    "source": [
     "> STOP - Select some data points from the plot above using the lasso or box select tool. Notice that the selection updates."
@@ -235,7 +235,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83304668",
+   "id": "fd7c7206",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -244,7 +244,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cf681d53",
+   "id": "1e1f0876",
    "metadata": {},
    "source": [
     "### 3. Interactively Select Objects from a Scatter Plot and Create Postage Stamp Cutouts\n",
@@ -254,7 +254,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2206b5ee",
+   "id": "451e13b7",
    "metadata": {},
    "source": [
     "We directly borrow the postage stamp image cutout function from the `03_Image_Display_and_Manipulation` tutorial."
@@ -263,7 +263,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4278870a",
+   "id": "ac5b5aa2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -319,7 +319,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "430fab11",
+   "id": "bb843fa6",
    "metadata": {},
    "source": [
     "Now we are ready to create the interactive display. Try selecting different objects in the scatter plot and see the cutout image update."
@@ -328,7 +328,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bbe435f2",
+   "id": "db0737e9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -346,8 +346,8 @@
     "detections.opts(\n",
     "    tools=['tap'], \n",
     "    height=600, width=600, logx=True, logy=True, xlim=(1, 1.e5),\n",
-    "    fill_color=None, size=9, color=\"darkorange\",\n",
-    "    nonselection_fill_color='silver', nonselection_line_color='silver')\n",
+    "    fill_color='darkorange', size=9, color=\"darkorange\",\n",
+    "    nonselection_fill_color='none', nonselection_line_color='black')\n",
     "\n",
     "# Selection from the scatter plot\n",
     "selection = streams.Selection1D(source=detections)\n",
@@ -381,7 +381,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3b0c3274",
+   "id": "babd3ada",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
This PR adds a notebook with examples of image-catalog interactivity using bokeh / holoviews.

1. Interactively Select Objects Overlaid on an Image with an Adjustable Colorbar Range
2. Interactively Select Objects from a Scatter Plot and Create Postage Stamp Cutouts