### PR TITLE
butler line regarding immediate=True removed

### DIFF
--- a/Structure/StructureAroundCluster/StructureAroundCluster_090521.ipynb
+++ b/Structure/StructureAroundCluster/StructureAroundCluster_090521.ipynb
@@ -179,7 +179,7 @@
     "    parameters = {'bbox': bbox}\n",
     "\n",
     "    cutout_image = butler.get(datasetType, parameters=parameters,\n",
-    "                              immediate=True, dataId=coaddId)\n",
+    "                               dataId=coaddId)\n",
     "\n",
     "    return cutout_image"
    ]


### PR DESCRIPTION
butler command has depreciated use of immediate=True option. This statement has been removed from the code to adhere to butler updates.